### PR TITLE
Fix missing datetime module import

### DIFF
--- a/exoscale_auth.py
+++ b/exoscale_auth.py
@@ -5,6 +5,7 @@ import hmac
 import time
 
 from base64 import standard_b64encode
+from datetime import datetime
 from urllib.parse import urlparse, parse_qs
 
 from requests.auth import AuthBase


### PR DESCRIPTION
This change restores importing of the `datetime` module dropped by
accident in commit 177c0f0.