### PR TITLE
Ensure all elements of msg_parts are byte strings

### DIFF
--- a/exoscale_auth.py
+++ b/exoscale_auth.py
@@ -79,7 +79,7 @@ class ExoscaleV2Auth(AuthBase):
         msg_parts.append(str(expiration_ts).encode('utf-8'))
         auth_header += ',expires=' + str(expiration_ts)
 
-        msg = b'\n'.join(msg_parts)
+        msg = b'\n'.join([part.encode() if isinstance(part, str) else part for part in msg_parts])
         signature = hmac.new(
             self.secret, msg=msg, digestmod=hashlib.sha256
         ).digest()

--- a/tests/test_exoscale_auth.py
+++ b/tests/test_exoscale_auth.py
@@ -60,3 +60,15 @@ class TestExoscaleV2Auth:
             + ',expires=' + str(self.expiration_ts)
             + ',signature=duldkM0+pgWRtUznj0rMrZauzsYOtSVLn1LCGcs7CcE='
         )
+
+    def test_sign_request_with_str_msg_parts(self):
+        auth = ExoscaleV2Auth(key=_API_KEY, secret=_API_SECRET)
+        req = requests.Request(
+            'GET',
+            'https://api.exoscale.com/v2/zone',
+            params={'k1': 'v1', 'k2': 'v2'},
+        ).prepare()
+        # explicitly set a string value to request body
+        req.body = "string body"
+        auth._sign_request(req, self.expiration_ts)
+        assert 'Authorization' in req.headers


### PR DESCRIPTION
When signing the request, this commit ensures that all elements in the msg_parts list are byte strings before they are joined. Previously, if any element was a regular string, it was joined without being encoded, which could cause issues in certain circumstances.

This fix adds a check to encode all string elements to bytes using UTF-8 encoding, ensuring the correct and expected behavior across all possible inputs. (Resolves #7)

I added a regression test case too.